### PR TITLE
Bugfix #4 in Forever.java

### DIFF
--- a/app/src/main/java/lu/fisch/structorizer/elements/Forever.java
+++ b/app/src/main/java/lu/fisch/structorizer/elements/Forever.java
@@ -30,9 +30,10 @@ package lu.fisch.structorizer.elements;
  *
  *      Revision List
  *
- *      Author          Date			Description
- *      ------			----			-----------
+ *      Author          Date            Description
+ *      ------          ----            -----------
  *      Bob Fisch       2008.02.06      First Issue
+ *      Kay Gürtzig     2018.09.11      Bugfix #4 in copy()
  *
  ******************************************************************************************************
  *
@@ -229,7 +230,7 @@ public class Forever extends Element{
 	
 	public Element copy()
 	{
-		Element ele = new For(this.getText().copy());
+		Element ele = new Forever(this.getText().copy());
 		ele.setComment(this.getComment().copy());
 		ele.setColor(this.getColor());
 		((For) ele).q=(Subqueue) this.q.copy();


### PR DESCRIPTION
Method `copy()` created a `For` loop instead of a `Forever` loop.
(I don't know whether the Android app is used at all, but it doesn't cause harm to fix this bug known from the Desktop version.)